### PR TITLE
[Bugfix] - Keyboard Notification Management

### DIFF
--- a/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
+++ b/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
@@ -28,10 +28,16 @@ extension UIViewController {
     static func runOnceSwapSelectors() {
         swizzle(
             UIViewController.self,
-            originalSelector: #selector(UIViewController.viewDidLoad),
-            swizzledSelector: #selector(UIViewController.swizzled_viewDidLoad)
+            originalSelector: #selector(UIViewController.viewWillAppear),
+            swizzledSelector: #selector(UIViewController.swizzled_viewWillAppear)
         )
-
+        
+        swizzle(
+            UIViewController.self,
+            originalSelector: #selector(UIViewController.viewWillDisappear),
+            swizzledSelector: #selector(UIViewController.swizzled_viewWillDisappear)
+        )
+        
         swizzle(
             UIViewController.self,
             originalSelector: #selector(getter: UIViewController.hidesBottomBarWhenPushed),
@@ -39,9 +45,14 @@ extension UIViewController {
         )
     }
 
-    @objc private func swizzled_viewDidLoad() {
-        self.swizzled_viewDidLoad()
+    @objc private func swizzled_viewWillAppear() {
+        self.swizzled_viewWillAppear()
         _addKeyboardNotificationObservers()
+    }
+
+    @objc private func swizzled_viewWillDisappear() {
+        self.swizzled_viewWillDisappear()
+        _removeKeyboardNotificationObservers()
     }
 
     /// A swizzled function to ensure that `hidesBottomBarWhenPushed` value is

--- a/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
+++ b/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
@@ -31,13 +31,13 @@ extension UIViewController {
             originalSelector: #selector(UIViewController.viewWillAppear),
             swizzledSelector: #selector(UIViewController.swizzled_viewWillAppear)
         )
-        
+
         swizzle(
             UIViewController.self,
             originalSelector: #selector(UIViewController.viewWillDisappear),
             swizzledSelector: #selector(UIViewController.swizzled_viewWillDisappear)
         )
-        
+
         swizzle(
             UIViewController.self,
             originalSelector: #selector(getter: UIViewController.hidesBottomBarWhenPushed),

--- a/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
+++ b/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
@@ -26,12 +26,12 @@ import UIKit
 
 extension UIViewController {
     private struct AssociatedKey {
-        static var didAddKeyboardToViewControllerNotificationObservers = "didAddKeyboardToViewControllerNotificationObservers"
+        static var didAddKeyboardNotificationObservers = "didAddKeyboardNotificationObservers"
     }
 
-    private var didAddKeyboardToViewControllerNotificationObservers: Bool {
-        get { return associatedObject(&AssociatedKey.didAddKeyboardToViewControllerNotificationObservers, default: false) }
-        set { setAssociatedObject(&AssociatedKey.didAddKeyboardToViewControllerNotificationObservers, value: newValue) }
+    private var didAddKeyboardNotificationObservers: Bool {
+        get { return associatedObject(&AssociatedKey.didAddKeyboardNotificationObservers, default: false) }
+        set { setAssociatedObject(&AssociatedKey.didAddKeyboardNotificationObservers, value: newValue) }
     }
 
     static func runOnceSwapSelectors() {
@@ -61,17 +61,17 @@ extension UIViewController {
     /// with the popping progress.
     @objc private func swizzled_viewDidAppear() {
         self.swizzled_viewDidAppear()
-        if !didAddKeyboardToViewControllerNotificationObservers {
+        if !didAddKeyboardNotificationObservers {
             _addKeyboardNotificationObservers()
-            didAddKeyboardToViewControllerNotificationObservers = true
+            didAddKeyboardNotificationObservers = true
         }
     }
 
     @objc private func swizzled_viewWillDisappear() {
         self.swizzled_viewWillDisappear()
-        if didAddKeyboardToViewControllerNotificationObservers {
+        if didAddKeyboardNotificationObservers {
             _removeKeyboardNotificationObservers()
-            didAddKeyboardToViewControllerNotificationObservers = false
+            didAddKeyboardNotificationObservers = false
         }
     }
 
@@ -97,12 +97,12 @@ extension UIViewController {
 
 extension UIView {
     private struct AssociatedKey {
-        static var didAddKeyboardToViewNotificationObservers = "didAddKeyboardToViewNotificationObservers"
+        static var didAddKeyboardNotificationObservers = "didAddKeyboardNotificationObservers"
     }
 
-    private var didAddKeyboardToViewNotificationObservers: Bool {
-        get { return associatedObject(&AssociatedKey.didAddKeyboardToViewNotificationObservers, default: false) }
-        set { setAssociatedObject(&AssociatedKey.didAddKeyboardToViewNotificationObservers, value: newValue) }
+    private var didAddKeyboardNotificationObservers: Bool {
+        get { return associatedObject(&AssociatedKey.didAddKeyboardNotificationObservers, default: false) }
+        set { setAssociatedObject(&AssociatedKey.didAddKeyboardNotificationObservers, value: newValue) }
     }
 
     static func _runOnceSwapSelectors() {
@@ -115,9 +115,9 @@ extension UIView {
 
     @objc private func swizzled_view_layoutSubviews() {
         self.swizzled_view_layoutSubviews()
-        if !didAddKeyboardToViewNotificationObservers {
+        if !didAddKeyboardNotificationObservers {
             _addKeyboardNotificationObservers()
-            didAddKeyboardToViewNotificationObservers = true
+            didAddKeyboardNotificationObservers = true
         }
     }
 }

--- a/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
+++ b/Sources/Cocoa/Extensions/UIViewController+HidesBottomBarWhenPushed.swift
@@ -54,6 +54,11 @@ extension UIViewController {
         )
     }
 
+    /// Swizzled viewDidAppear and viewWillDisappear for keyboard notifications.
+    /// Registering keyboard notifications in `viewDidLoad` results in
+    /// unexpected keyboard behavior: when popping the viewController
+    /// while the keyboard is presented, keyboard will not dismiss in concurrent
+    /// with the popping progress.
     @objc private func swizzled_viewDidAppear() {
         self.swizzled_viewDidAppear()
         if !didAddKeyboardToViewControllerNotificationObservers {

--- a/Sources/Cocoa/Protocols/KeyboardObservable.swift
+++ b/Sources/Cocoa/Protocols/KeyboardObservable.swift
@@ -182,14 +182,13 @@ extension UIViewController {
             isViewLoaded,
             let observable = self as? KeyboardObservable,
             view.firstResponder != nil,
-            let payload = KeyboardPayload(notification: notification, willShow: willShow),
-            payload.frameBegin.origin.y != payload.frameEnd.origin.y
+            let payload = KeyboardPayload(notification: notification, willShow: willShow)
         else {
             return
         }
 
         observable.keyboardFrameDidChange(payload)
-        self.view.layoutIfNeeded()
+        view.layoutIfNeeded()
     }
 }
 
@@ -237,14 +236,13 @@ extension UIView {
         guard
             let observable = self as? KeyboardObservable,
             firstResponder != nil,
-            let payload = KeyboardPayload(notification: notification, willShow: willShow),
-            payload.frameBegin.origin.y != payload.frameEnd.origin.y
+            let payload = KeyboardPayload(notification: notification, willShow: willShow)
         else {
             return
         }
 
         observable.keyboardFrameDidChange(payload)
-        self.layoutIfNeeded()
+        layoutIfNeeded()
     }
 }
 

--- a/Sources/Cocoa/Protocols/KeyboardObservable.swift
+++ b/Sources/Cocoa/Protocols/KeyboardObservable.swift
@@ -132,14 +132,14 @@ extension UIViewController {
         guard (self as? KeyboardObservable) != nil else {
             return
         }
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow(_:)),
             name: UIResponder.keyboardWillShowNotification,
             object: nil
         )
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillHide(_:)),
@@ -147,7 +147,7 @@ extension UIViewController {
             object: nil
         )
     }
-    
+
     /// This method automatically deregisters keyboard notification observers for any
     /// view controller that conforms to `KeyboardObservable` using `viewWillDisappear`
     /// method swizzling.


### PR DESCRIPTION
# Change Log
- fixed issue when keyboard height wasn't passing back the expected value;
- subscribe/unsubscribe keyboard event observers on more appropriate UIViewController instance methods.