### PR TITLE
CarouselCollectionView Fix

### DIFF
--- a/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
@@ -37,7 +37,6 @@ final class CarouselCollectionView
     var viewModel: Model? {
         didSet {
             reloadData()
-            setCurrentIndex(0)
         }
     }
 
@@ -57,7 +56,6 @@ final class CarouselCollectionView
         guard bounds.width > 0, numberOfItems > 0 else {
             return 0
         }
-
         if style == .infiniteScroll {
             return (Int(round(adjustedOffset / bounds.width)) + numberOfItems) % numberOfItems
         }

--- a/Sources/Cocoa/Components/CarouselView/CarouselView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselView.swift
@@ -9,7 +9,7 @@ import UIKit
 // MARK: - CarouselView
 
 final public class CarouselView<Cell: CarouselViewCellType>: CustomCarouselView<Cell, CarouselViewModel<Cell.Model>> where Cell.Model: CarouselAccessibilitySupport {
-    public func configure(items: [Cell.Model], currentIndex: Int) {
+    public func configure(items: [Cell.Model], currentIndex: Int = 0) {
         let model = CarouselViewModel<Cell.Model>(items: items)
         super.configure(model: model, currentIndex: currentIndex)
     }
@@ -226,7 +226,7 @@ open class CustomCarouselView<Cell: CarouselViewCellType, Model: CarouselViewMod
         carouselCollectionView.setCurrentIndex(index, animated: animated, completion: completion)
     }
 
-    open func configure(model: Model, currentIndex: Int) {
+    open func configure(model: Model, currentIndex: Int = 0) {
         carouselCollectionView.viewModel = model
         pageControl.isHidden = isPageControlHidden
         pageControl.numberOfPages = carouselCollectionView.numberOfPages

--- a/Sources/Cocoa/Components/CarouselView/CarouselView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselView.swift
@@ -9,9 +9,9 @@ import UIKit
 // MARK: - CarouselView
 
 final public class CarouselView<Cell: CarouselViewCellType>: CustomCarouselView<Cell, CarouselViewModel<Cell.Model>> where Cell.Model: CarouselAccessibilitySupport {
-    public func configure(items: [Cell.Model]) {
+    public func configure(items: [Cell.Model], currentIndex: Int) {
         let model = CarouselViewModel<Cell.Model>(items: items)
-        super.configure(model: model)
+        super.configure(model: model, currentIndex: currentIndex)
     }
 }
 
@@ -226,10 +226,11 @@ open class CustomCarouselView<Cell: CarouselViewCellType, Model: CarouselViewMod
         carouselCollectionView.setCurrentIndex(index, animated: animated, completion: completion)
     }
 
-    open func configure(model: Model) {
+    open func configure(model: Model, currentIndex: Int) {
         carouselCollectionView.viewModel = model
         pageControl.isHidden = isPageControlHidden
         pageControl.numberOfPages = carouselCollectionView.numberOfPages
+        setCurrentIndex(currentIndex, animated: false)
     }
 
     // MARK: - Hooks


### PR DESCRIPTION
> When configuring the view with new items, the currently selected index is now explicitly set, instead of defaulting to 0.

The previous behavior would cause issues where container classes (such as CarouselView) would have a selected index out of sync from the CarouselCollectionView instance. It would also cause problems if the view is used in a table or collection cell since the index would be reset when the cell is reused.