### PR TITLE
Money format

### DIFF
--- a/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter+Format.swift
+++ b/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter+Format.swift
@@ -36,7 +36,7 @@ extension CurrencyFormatter {
             return formattedMoney
         }
 
-        let mainFormat = NSMutableAttributedString(string: format, attributes: mayorUnitFont(money))
+        let mainFormat = NSMutableAttributedString(string: format, attributes: majorUnitFont(money))
         mainFormat.replaceCharacters(in: range, with: formattedMoney)
         return mainFormat
     }
@@ -65,7 +65,7 @@ extension CurrencyFormatter {
 
         let attributedString = NSMutableAttributedString(
             string: joinedAmount,
-            attributes: mayorUnitFont(money)
+            attributes: majorUnitFont(money)
         )
 
         guard money.shouldSuperscriptMinorUnit else {
@@ -97,17 +97,21 @@ extension CurrencyFormatter {
 
         return foregroundColor
     }
+}
 
-    private func mayorUnitFont(_ money: Money) -> [NSAttributedString.Key: Any] {
-        [
-            .font: money.font.majorUnit
-        ].compactMapValues { $0 }
+// MARK: - Helpers
+
+extension CurrencyFormatter {
+    private func majorUnitFont(_ money: Money) -> [NSAttributedString.Key: Any] {
+        [.font: money.font.majorUnit].compactMapValues { $0 }
     }
 
     private func minorUnitFont(_ money: Money) -> [NSAttributedString.Key: Any] {
-        [
+        let attributes: [NSAttributedString.Key: Any?] = [
             .font: money.font.minorUnit,
             .baselineOffset: money.font.minorUnitOffset
-        ].compactMapValues { $0 }
+        ]
+
+        return attributes.compactMapValues { $0 }
     }
 }

--- a/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter+Format.swift
+++ b/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter+Format.swift
@@ -36,9 +36,7 @@ extension CurrencyFormatter {
             return formattedMoney
         }
 
-        let mainFormat = NSMutableAttributedString(string: format, attributes: [
-            .font: money.font.majorUnit
-        ])
+        let mainFormat = NSMutableAttributedString(string: format, attributes: mayorUnitFont(money))
         mainFormat.replaceCharacters(in: range, with: formattedMoney)
         return mainFormat
     }
@@ -67,7 +65,7 @@ extension CurrencyFormatter {
 
         let attributedString = NSMutableAttributedString(
             string: joinedAmount,
-            attributes: [.font: money.font.majorUnit]
+            attributes: mayorUnitFont(money)
         )
 
         guard money.shouldSuperscriptMinorUnit else {
@@ -75,10 +73,7 @@ extension CurrencyFormatter {
         }
 
         if let minorUnitRange = components.range(style: money.style).minorUnit {
-            attributedString.setAttributes([
-                .font: money.font.minorUnit,
-                .baselineOffset: money.font.minorUnitOffset
-            ], range: minorUnitRange)
+            attributedString.setAttributes(minorUnitFont(money), range: minorUnitRange)
         }
 
         return attributedString
@@ -101,5 +96,18 @@ extension CurrencyFormatter {
         }
 
         return foregroundColor
+    }
+
+    private func mayorUnitFont(_ money: Money) -> [NSAttributedString.Key: Any] {
+        [
+            .font: money.font.majorUnit
+        ].compactMapValues { $0 }
+    }
+
+    private func minorUnitFont(_ money: Money) -> [NSAttributedString.Key: Any] {
+        [
+            .font: money.font.minorUnit,
+            .baselineOffset: money.font.minorUnitOffset
+        ].compactMapValues { $0 }
     }
 }

--- a/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
+++ b/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
@@ -10,6 +10,7 @@ public class CurrencyFormatter: Currency.SymbolsProvider {
     public static let shared = CurrencyFormatter()
 
     /// This formatter must be used only to transform Double values into US dollars.
+    /// Reference: http://unicode.org/reports/tr35/tr35-10.html#Number_Format_Patterns
     private lazy var formatter = NumberFormatter().apply {
         $0.numberStyle = .currency
         $0.locale = locale

--- a/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
+++ b/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
@@ -14,8 +14,8 @@ public class CurrencyFormatter: Currency.SymbolsProvider {
     private lazy var formatter = NumberFormatter().apply {
         $0.numberStyle = .currency
         $0.locale = locale
-        $0.positiveFormat = defaultPositiveFormat
-        $0.negativeFormat = defaultNegativeFormat
+        $0.positiveFormat = "¤#,##0.00"
+        $0.negativeFormat = "-¤#,##0.00"
         // We need to add the $-Symbol manually in order to support different locals but
         // keep $ sign at the correct position to keep the design consistent
         // (i.e., Germany: 1.000,11 $ -> $1.000,11).
@@ -23,14 +23,7 @@ public class CurrencyFormatter: Currency.SymbolsProvider {
         $0.isDecimalEnabled = true
     }
 
-    // Separators will get replaced by locale ones.
-    /// `¤#,##0.00`
-    private let defaultPositiveFormat = "¤#,##0.00"
-    /// `-¤#,##0.00`
-    private let defaultNegativeFormat = "-¤#,##0.00"
-
     private let defaultPlusSign = ""
-
     private let defaultMinusSign = "-"
 
     /// The locale of the receiver.

--- a/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
+++ b/Sources/Cocoa/Components/Currency/CurrencyFormatter/CurrencyFormatter.swift
@@ -24,8 +24,6 @@ public class CurrencyFormatter: Currency.SymbolsProvider {
 
     // Separators will get replaced by locale ones.
     /// `¤#,##0.00`
-    private let defaultFormat = "¤#,##0.00"
-    /// `¤#,##0.00`
     private let defaultPositiveFormat = "¤#,##0.00"
     /// `-¤#,##0.00`
     private let defaultNegativeFormat = "-¤#,##0.00"
@@ -84,41 +82,39 @@ extension CurrencyFormatter {
         var majorUnitString = "0"
         var minorUnitString = "00"
 
-        return synchronized(formatter) {
-            // Important to ensure decimal is enabled since the formatter is shared
-            // instance potentially mutated by other code.
-            formatter.isDecimalEnabled = true
+        // Important to ensure decimal is enabled since the formatter is shared
+        // instance potentially mutated by other code.
+        formatter.isDecimalEnabled = true
 
-            let amountString = with(sign: sign) {
-                formatter.string(from: NSDecimalNumber(decimal: amount))!
-            }
+        let amountString = with(sign: sign) {
+             formatter.string(from: NSDecimalNumber(decimal: amount))!
+        }
 
-            let pieces = amountString.components(separatedBy: decimalSeparator)
+        let pieces = amountString.components(separatedBy: decimalSeparator)
 
-            if let majorUnit = pieces.first {
-                majorUnitString = majorUnit
-            }
+        if let majorUnit = pieces.first {
+            majorUnitString = majorUnit
+        }
 
-            if pieces.count > 1 {
-                let rawMinorUnitString = pieces[1] as NSString
-                let range = NSRange(location: 0, length: rawMinorUnitString.length)
-                minorUnitString = rawMinorUnitString.replacingOccurrences(
-                    of: "\\D",
-                    with: "",
-                    options: .regularExpression,
-                    range: range
-                )
-            }
-
-            return .init(
-                amount: amount,
-                majorUnit: majorUnitString,
-                minorUnit: minorUnitString,
-                currencySymbol: currencySymbol,
-                groupingSeparator: groupingSeparator,
-                decimalSeparator: decimalSeparator
+        if pieces.count > 1 {
+            let rawMinorUnitString = pieces[1] as NSString
+            let range = NSRange(location: 0, length: rawMinorUnitString.length)
+            minorUnitString = rawMinorUnitString.replacingOccurrences(
+                of: "\\D",
+                with: "",
+                options: .regularExpression,
+                range: range
             )
         }
+
+        return .init(
+            amount: amount,
+            majorUnit: majorUnitString,
+            minorUnit: minorUnitString,
+            currencySymbol: currencySymbol,
+            groupingSeparator: groupingSeparator,
+            decimalSeparator: decimalSeparator
+        )
     }
 }
 

--- a/Sources/Cocoa/Components/Currency/Money/Money+Components+Font.swift
+++ b/Sources/Cocoa/Components/Currency/Money/Money+Components+Font.swift
@@ -16,7 +16,7 @@ extension Money.Components {
         /// // 120 - major unit
         /// // 30 - minor unit
         /// ```
-        public let majorUnit: UIFont
+        public let majorUnit: UIFont?
 
         /// The font to be used in displaying minor unit of the amount.
         ///
@@ -25,7 +25,7 @@ extension Money.Components {
         /// // 120 - major unit
         /// // 30 - minor unit
         /// ```
-        public let minorUnit: UIFont
+        public let minorUnit: UIFont?
 
         /// The offset applied to the minor unit of the amount.
         ///
@@ -34,9 +34,9 @@ extension Money.Components {
         /// // 120 - major unit
         /// // 30 - minor unit
         /// ```
-        public let minorUnitOffset: Int
+        public let minorUnitOffset: Int?
 
-        public init(majorUnit: UIFont, minorUnit: UIFont, minorUnitOffset: Int) {
+        public init(majorUnit: UIFont?, minorUnit: UIFont?, minorUnitOffset: Int?) {
             self.majorUnit = majorUnit
             self.minorUnit = minorUnit
             self.minorUnitOffset = minorUnitOffset
@@ -46,7 +46,7 @@ extension Money.Components {
             self.init(.app(style: style))
         }
 
-        public init(_ font: UIFont) {
+        public init(_ font: UIFont?) {
             self.majorUnit = font
             self.minorUnit = font
             self.minorUnitOffset = 0
@@ -184,5 +184,9 @@ extension Money.Components.Font {
 
     public static func caption2(superscript: Bool) -> Self {
         superscript ? .superscript(.caption2) : .init(.caption2)
+    }
+
+    public static var none: Self {
+        .init(nil)
     }
 }

--- a/Sources/Cocoa/Components/Currency/Money/Money+Components+Font.swift
+++ b/Sources/Cocoa/Components/Currency/Money/Money+Components+Font.swift
@@ -49,7 +49,7 @@ extension Money.Components {
         public init(_ font: UIFont?) {
             self.majorUnit = font
             self.minorUnit = font
-            self.minorUnitOffset = 0
+            self.minorUnitOffset = nil
         }
     }
 }

--- a/Sources/Cocoa/Components/Currency/Money/Money.swift
+++ b/Sources/Cocoa/Components/Currency/Money/Money.swift
@@ -49,8 +49,8 @@ public struct Money: Equatable, Hashable, MutableAppliable {
 
     /// The font used to display money components.
     ///
-    /// The default value is `.body`.
-    public var font: Components.Font = .body
+    /// The default value is `.none`.
+    public var font: Components.Font = .none
 
     /// The sign (+/-) used to format money components.
     ///

--- a/UnitTests/Components/Currency/CurrencyFormatterTests.swift
+++ b/UnitTests/Components/Currency/CurrencyFormatterTests.swift
@@ -110,6 +110,7 @@ final class CurrencyFormatterTests: TestCase {
 
         // Pakistan - Urdu
         CurrencyFormatter.shared.localeTest = .pakistanUrdu
+        let value1 = dollarsAndCents(from: -1000.0)
         XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-$1,000.", "00"))
         XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$0.", "00"))
@@ -118,6 +119,7 @@ final class CurrencyFormatterTests: TestCase {
 
         // Pakistan - Punjabi
         CurrencyFormatter.shared.localeTest = .pakistanPunjabi
+        let value2 = dollarsAndCents(from: -1000.0)
         XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-‎$۱٬۰۰۰٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-‎$۱٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$۰٫", "۰۰"))

--- a/UnitTests/Components/Currency/CurrencyFormatterTests.swift
+++ b/UnitTests/Components/Currency/CurrencyFormatterTests.swift
@@ -110,24 +110,24 @@ final class CurrencyFormatterTests: TestCase {
 
         // Pakistan - Urdu
         CurrencyFormatter.shared.localeTest = .pakistanUrdu
-        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-$1,000.", "00"))
-        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-$1.", "00"))
+        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("-$1,000.", "00"))
+        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("-$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$0.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 1.0) == ("$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 1000.0) == ("$1,000.", "00"))
 
         // Pakistan - Punjabi
         CurrencyFormatter.shared.localeTest = .pakistanPunjabi
-        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-‎$۱٬۰۰۰٫", "۰۰"))
-        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-‎$۱٫", "۰۰"))
+        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("-$۱٬۰۰۰٫", "۰۰"))
+        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("-$۱٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$۰٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: 1.0) == ("$۱٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: 1000.0) == ("$۱٬۰۰۰٫", "۰۰"))
 
         // Switzerland
         CurrencyFormatter.shared.localeTest = .switzerland
-        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("−$1’000.", "00"))
-        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("−$1.", "00"))
+        XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("-$1’000.", "00"))
+        XCTAssertTrue(dollarsAndCents(from: -1.0) == ("-$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$0.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 1.0) == ("$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 1000.0) == ("$1’000.", "00"))

--- a/UnitTests/Components/Currency/CurrencyFormatterTests.swift
+++ b/UnitTests/Components/Currency/CurrencyFormatterTests.swift
@@ -110,7 +110,6 @@ final class CurrencyFormatterTests: TestCase {
 
         // Pakistan - Urdu
         CurrencyFormatter.shared.localeTest = .pakistanUrdu
-        let value1 = dollarsAndCents(from: -1000.0)
         XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-$1,000.", "00"))
         XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-$1.", "00"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$0.", "00"))
@@ -119,7 +118,6 @@ final class CurrencyFormatterTests: TestCase {
 
         // Pakistan - Punjabi
         CurrencyFormatter.shared.localeTest = .pakistanPunjabi
-        let value2 = dollarsAndCents(from: -1000.0)
         XCTAssertTrue(dollarsAndCents(from: -1000.0) == ("‎-‎$۱٬۰۰۰٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: -1.0) == ("‎-‎$۱٫", "۰۰"))
         XCTAssertTrue(dollarsAndCents(from: 0.0) == ("$۰٫", "۰۰"))

--- a/UnitTests/Components/Currency/MoneyTests.swift
+++ b/UnitTests/Components/Currency/MoneyTests.swift
@@ -27,6 +27,12 @@ final class MoneyTests: TestCase {
              .style(.default)
 
         XCTAssert(String(describing: amount3) == "$120.00")
+
+        let amount4 = Money(-120)
+            .style(.default)
+            .signed()
+
+        XCTAssert(String(describing: amount4) == "-$120.00")
     }
 
     func testMoneyStyles_removeMinorUnit() {

--- a/UnitTests/Components/Currency/MoneyTests.swift
+++ b/UnitTests/Components/Currency/MoneyTests.swift
@@ -22,6 +22,11 @@ final class MoneyTests: TestCase {
              .style(.default)
 
         XCTAssert(String(describing: amount2) == "$120.00")
+
+        let amount3 = Money(-120)
+             .style(.default)
+
+        XCTAssert(String(describing: amount3) == "$120.00")
     }
 
     func testMoneyStyles_removeMinorUnit() {


### PR DESCRIPTION
# Changelog
Fix for Money Format on ios 12.0
Allow to configure Money with empty font (so it takes the uilabel one as default)