### PR TITLE
Accessibility updates to LabelTextView and UILabel

### DIFF
--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -152,21 +152,12 @@ extension LabelTextView {
         get {
             guard
                 let currentFont = font,
-                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle
+                let textStyle = currentFont.textStyle
             else {
                 return super.accessibilityTraits
             }
 
-            switch textStyle {
-                case UIFont.TextStyle.title1,
-                     UIFont.TextStyle.title2,
-                     UIFont.TextStyle.title3,
-                     UIFont.TextStyle.headline,
-                     UIFont.TextStyle.largeTitle:
-                    return .header
-                default:
-                    return super.accessibilityTraits
-            }
+            return textStyle.isTitle ? .header : super.accessibilityTraits
         }
         set { super.accessibilityTraits = newValue }
     }

--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -41,6 +41,7 @@ open class LabelTextView: UITextView {
         #if canImport(Haring)
         isAccessibilityRotorHintEnabled = true
         #endif
+        isAccessibilityElement = true
         dataDetectorTypes = .all
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
@@ -141,3 +142,32 @@ extension LabelTextView {
         set { super.linkTextAttributes = newValue }
     }
 }
+
+// MARK: - Accessibility
+
+extension LabelTextView {
+    /// The accessibility trait value that the element takes based on the
+    /// text style it was given when created.
+     open override var accessibilityTraits: UIAccessibilityTraits {
+        get {
+            guard
+                let currentFont = font,
+                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle)
+            else {
+                return super.accessibilityTraits
+            }
+
+            switch textStyle as! UIFont.TextStyle {
+                case UIFont.TextStyle.title1,
+                     UIFont.TextStyle.title2,
+                     UIFont.TextStyle.title3,
+                     UIFont.TextStyle.headline:
+                    return .header
+                default:
+                    return super.accessibilityTraits
+            }
+        }
+        set { super.accessibilityTraits = newValue }
+    }
+}
+

--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -152,12 +152,12 @@ extension LabelTextView {
         get {
             guard
                 let currentFont = font,
-                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle)
+                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle
             else {
                 return super.accessibilityTraits
             }
 
-            switch textStyle as! UIFont.TextStyle {
+            switch textStyle {
                 case UIFont.TextStyle.title1,
                      UIFont.TextStyle.title2,
                      UIFont.TextStyle.title3,

--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -146,8 +146,8 @@ extension LabelTextView {
 // MARK: - Accessibility
 
 extension LabelTextView {
-    /// The accessibility trait value that the element takes based on the
-    /// text style it was given when created.
+    /// The accessibility trait value that the element takes based on the text style
+    /// it was given when created.
      open override var accessibilityTraits: UIAccessibilityTraits {
         get {
             guard

--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -161,7 +161,8 @@ extension LabelTextView {
                 case UIFont.TextStyle.title1,
                      UIFont.TextStyle.title2,
                      UIFont.TextStyle.title3,
-                     UIFont.TextStyle.headline:
+                     UIFont.TextStyle.headline,
+                     UIFont.TextStyle.largeTitle:
                     return .header
                 default:
                     return super.accessibilityTraits
@@ -170,4 +171,3 @@ extension LabelTextView {
         set { super.accessibilityTraits = newValue }
     }
 }
-

--- a/Sources/Cocoa/Extensions/UIFont/UIFont+App.swift
+++ b/Sources/Cocoa/Extensions/UIFont/UIFont+App.swift
@@ -71,11 +71,11 @@ extension UIFont {
         style: UIFont.TextStyle,
         compatibleWith traitCollection: UITraitCollection? = nil
     ) -> UIFont {
-        let preferredPointSize = UIFontDescriptor.preferredFontDescriptor(
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(
             withTextStyle: style,
             compatibleWith: traitCollection
-        ).pointSize
+        ).addingAttributes([.name : name])
 
-        return UIFont(name: name, size: preferredPointSize)!
+        return UIFont(descriptor: fontDescriptor, size: fontDescriptor.pointSize)
     }
 }

--- a/Sources/Cocoa/Extensions/UIFont/UIFont+App.swift
+++ b/Sources/Cocoa/Extensions/UIFont/UIFont+App.swift
@@ -74,7 +74,7 @@ extension UIFont {
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(
             withTextStyle: style,
             compatibleWith: traitCollection
-        ).addingAttributes([.name : name])
+        ).addingAttributes([.name: name])
 
         return UIFont(descriptor: fontDescriptor, size: fontDescriptor.pointSize)
     }

--- a/Sources/Cocoa/Extensions/UIFont/UIFont+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UIFont/UIFont+Extensions.swift
@@ -81,6 +81,12 @@ extension UIFont {
     }
 }
 
+extension UIFont {
+    public var textStyle: UIFont.TextStyle? {
+        self.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle
+    }
+}
+
 extension UIFont.TextStyle: CaseIterable {
     public static var allCases: [UIFont.TextStyle] = {
         [

--- a/Sources/Cocoa/Extensions/UILabel+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UILabel+Extensions.swift
@@ -150,7 +150,7 @@ extension UILabel {
     }
 }
 
-// MARK: Accessibility
+// MARK: - Accessibility
 
 extension UILabel {
     /// The accessibility trait value that the element takes based on the text style

--- a/Sources/Cocoa/Extensions/UILabel+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UILabel+Extensions.swift
@@ -168,7 +168,8 @@ extension UILabel {
             case UIFont.TextStyle.title1,
                  UIFont.TextStyle.title2,
                  UIFont.TextStyle.title3,
-                 UIFont.TextStyle.headline:
+                 UIFont.TextStyle.headline,
+                 UIFont.TextStyle.largeTitle:
                 return .header
             default:
                 return super.accessibilityTraits

--- a/Sources/Cocoa/Extensions/UILabel+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UILabel+Extensions.swift
@@ -153,26 +153,26 @@ extension UILabel {
 // MARK: Accessibility
 
 extension UILabel {
-    /// The accessibility trait value that the element takes based on the
-    /// text style it was given when created.
+    /// The accessibility trait value that the element takes based on the text style
+    /// it was given when created.
     open override var accessibilityTraits: UIAccessibilityTraits {
         get {
             guard
                 let currentFont = font,
-                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle)
-                else {
-                    return super.accessibilityTraits
+                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle
+            else {
+                return super.accessibilityTraits
             }
 
-            switch textStyle as! UIFont.TextStyle {
-            case UIFont.TextStyle.title1,
-                 UIFont.TextStyle.title2,
-                 UIFont.TextStyle.title3,
-                 UIFont.TextStyle.headline,
-                 UIFont.TextStyle.largeTitle:
-                return .header
-            default:
-                return super.accessibilityTraits
+            switch textStyle {
+                case UIFont.TextStyle.title1,
+                     UIFont.TextStyle.title2,
+                     UIFont.TextStyle.title3,
+                     UIFont.TextStyle.headline,
+                     UIFont.TextStyle.largeTitle:
+                    return .header
+                default:
+                    return super.accessibilityTraits
             }
         }
         set { super.accessibilityTraits = newValue }

--- a/Sources/Cocoa/Extensions/UILabel+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UILabel+Extensions.swift
@@ -149,3 +149,31 @@ extension UILabel {
         )
     }
 }
+
+// MARK: Accessibility
+
+extension UILabel {
+    /// The accessibility trait value that the element takes based on the
+    /// text style it was given when created.
+    open override var accessibilityTraits: UIAccessibilityTraits {
+        get {
+            guard
+                let currentFont = font,
+                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle)
+                else {
+                    return super.accessibilityTraits
+            }
+
+            switch textStyle as! UIFont.TextStyle {
+            case UIFont.TextStyle.title1,
+                 UIFont.TextStyle.title2,
+                 UIFont.TextStyle.title3,
+                 UIFont.TextStyle.headline:
+                return .header
+            default:
+                return super.accessibilityTraits
+            }
+        }
+        set { super.accessibilityTraits = newValue }
+    }
+}

--- a/Sources/Cocoa/Extensions/UILabel+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UILabel+Extensions.swift
@@ -157,23 +157,9 @@ extension UILabel {
     /// it was given when created.
     open override var accessibilityTraits: UIAccessibilityTraits {
         get {
-            guard
-                let currentFont = font,
-                let textStyle = currentFont.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle
-            else {
-                return super.accessibilityTraits
-            }
+            guard let textStyle = font.textStyle else { return super.accessibilityTraits }
 
-            switch textStyle {
-                case UIFont.TextStyle.title1,
-                     UIFont.TextStyle.title2,
-                     UIFont.TextStyle.title3,
-                     UIFont.TextStyle.headline,
-                     UIFont.TextStyle.largeTitle:
-                    return .header
-                default:
-                    return super.accessibilityTraits
-            }
+            return textStyle.isTitle ? .header : super.accessibilityTraits
         }
         set { super.accessibilityTraits = newValue }
     }


### PR DESCRIPTION
# **ChangeLog**

- add text style to font descriptor when using app method to set font
- override accessibility traits on label text view
- override accessibility traits on UILabel

I am proposing this change to LabelTextView and UILabel to solve the issue where we forget to add accessibility traits = .header when the text is a title. This will apply the accessibility trait automatically.  
Basically, when the text style is title1, 2, 3, or headline the default trait is .header unless the user specifies a different one.
In order to do this, I had to add text style attribute to font descriptor. 