### PR TITLE
[Fix] Search bar responding to search events rather than keyboard

### DIFF
--- a/Sources/Cocoa/Components/SearchBarView.swift
+++ b/Sources/Cocoa/Components/SearchBarView.swift
@@ -291,6 +291,8 @@ extension SearchBarView: UISearchBarDelegate {
 
     private func enableCancelButtonIfVisible() {
         guard searchBar.showsCancelButton else { return }
-        searchBar.subviews.flatMap({$0.subviews}).forEach({ ($0 as? UIButton)?.isEnabled = true })
+        searchBar.subviews.flatMap { $0.subviews }.forEach {
+            ($0 as? UIButton)?.isEnabled = true
+        }
     }
 }

--- a/Sources/Cocoa/Components/SearchBarView.swift
+++ b/Sources/Cocoa/Components/SearchBarView.swift
@@ -278,7 +278,6 @@ extension SearchBarView: UISearchBarDelegate {
     public func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
         guard hidesCancelButtonWhenEmptyAndDismissed else { return }
         hideCancelButtonIfNeeded()
-        enableCancelButtonIfVisible()
     }
 
     private func hideCancelButtonIfNeeded() {
@@ -286,13 +285,6 @@ extension SearchBarView: UISearchBarDelegate {
         // Only hide cancel button if no text is present in the search bar
         if isEmpty {
             searchBar.setShowsCancelButton(false, animated: true)
-        }
-    }
-
-    private func enableCancelButtonIfVisible() {
-        guard searchBar.showsCancelButton else { return }
-        searchBar.subviews.flatMap { $0.subviews }.forEach {
-            ($0 as? UIButton)?.isEnabled = true
         }
     }
 }

--- a/Sources/Cocoa/Components/SearchBarView.swift
+++ b/Sources/Cocoa/Components/SearchBarView.swift
@@ -292,26 +292,7 @@ extension SearchBarView: UISearchBarDelegate {
     private func enableCancelButtonIfVisible() {
         guard searchBar.showsCancelButton else { return }
         DispatchQueue.main.async { [weak self] in
-            Self.searchAndEnableButtonInSubviews(view: self?.searchBar)
+            self?.searchBar.firstSubview(withClass: UIButton.self)?.isEnabled = true
         }
-    }
-
-    @discardableResult
-    private static func searchAndEnableButtonInSubviews(view: UIView?) -> Bool {
-        guard let view = view else { return false }
-
-        if let button = view as? UIButton {
-            button.isEnabled = true
-            return true
-        }
-        guard !view.subviews.isEmpty else {
-            return false
-        }
-        for subview in view.subviews {
-            if searchAndEnableButtonInSubviews(view: subview) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/Sources/Cocoa/Components/SearchBarView.swift
+++ b/Sources/Cocoa/Components/SearchBarView.swift
@@ -215,20 +215,10 @@ final public class SearchBarView: UIView {
     }
 }
 
-extension SearchBarView: KeyboardObservable {
+extension SearchBarView {
     public func hideKeyboardIfNeeded() {
         guard searchBar.isFirstResponder else { return }
-        updateCancelButton(isKeyboardHidden: true)
         resignFirstResponder()
-    }
-
-    public func updateCancelButton(isKeyboardHidden: Bool) {
-        guard hidesCancelButtonWhenEmptyAndDismissed else { return }
-        let isEmpty = searchBar.text == nil || (searchBar.text != nil && searchBar.text!.isEmpty)
-        // Only hide cancel button if no text is present in the search bar
-        if isKeyboardHidden, isEmpty {
-            searchBar.setShowsCancelButton(false, animated: true)
-        }
     }
 
     public override var isFirstResponder: Bool {
@@ -249,11 +239,6 @@ extension SearchBarView: KeyboardObservable {
     @discardableResult
     public override func resignFirstResponder() -> Bool {
         searchBar.resignFirstResponder()
-    }
-
-    public func keyboardFrameDidChange(_ payload: KeyboardPayload) {
-        guard searchBar.isFirstResponder else { return }
-        updateCancelButton(isKeyboardHidden: payload.height == 0.0)
     }
 }
 
@@ -288,5 +273,24 @@ extension SearchBarView: UISearchBarDelegate {
 
     public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         hideKeyboardIfNeeded()
+    }
+
+    public func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        guard hidesCancelButtonWhenEmptyAndDismissed else { return }
+        hideCancelButtonIfNeeded()
+        enableCancelButtonIfVisible()
+    }
+
+    private func hideCancelButtonIfNeeded() {
+        let isEmpty = searchBar.text == nil || (searchBar.text != nil && searchBar.text!.isEmpty)
+        // Only hide cancel button if no text is present in the search bar
+        if isEmpty {
+            searchBar.setShowsCancelButton(false, animated: true)
+        }
+    }
+
+    private func enableCancelButtonIfVisible() {
+        guard searchBar.showsCancelButton else { return }
+        searchBar.subviews.flatMap({$0.subviews}).forEach({ ($0 as? UIButton)?.isEnabled = true })
     }
 }


### PR DESCRIPTION
# Changelog
Making search bar hide/show cancel button only when searchBar text did end editing