### PR TITLE
[Fix] Search bar cancel grayedout

### DIFF
--- a/Sources/Cocoa/Components/SearchBarView.swift
+++ b/Sources/Cocoa/Components/SearchBarView.swift
@@ -291,8 +291,27 @@ extension SearchBarView: UISearchBarDelegate {
 
     private func enableCancelButtonIfVisible() {
         guard searchBar.showsCancelButton else { return }
-        searchBar.subviews.flatMap { $0.subviews }.forEach {
-            ($0 as? UIButton)?.isEnabled = true
+        DispatchQueue.main.async { [weak self] in
+            Self.searchAndEnableButtonInSubviews(view: self?.searchBar)
         }
+    }
+
+    @discardableResult
+    private static func searchAndEnableButtonInSubviews(view: UIView?) -> Bool {
+        guard let view = view else { return false }
+
+        if let button = view as? UIButton {
+            button.isEnabled = true
+            return true
+        }
+        guard !view.subviews.isEmpty else {
+            return false
+        }
+        for subview in view.subviews {
+            if searchAndEnableButtonInSubviews(view: subview) {
+                return true
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
# Case
When the search loses focus, iOS automatically disables the Cancel button, making the user to have to tap twice (get focus, then cancel) if they want to cancel
# Proposal
The fix for this is to search the internal subview that is the cancel button and enable it when UIKit disables it, it's a `hack` that might not work in future versions if they change the hierarchy of the search bar, but it's harmless if that happens (no risk of crashes, no use of private api)