### PR TITLE
[Enhancement] Support additional views for CarouselAccessibilityItem

### DIFF
--- a/Sources/Cocoa/Components/CarouselView/CarouselViewTypes.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselViewTypes.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 public typealias CarouselViewCellType = UICollectionViewCell & CarouselViewCellRepresentable
-public typealias CarouselAccessibilityItem = (label: String, value: String)
+public typealias CarouselAccessibilityItem = (label: String, value: String, additionalViews: [Any]?)
 
 public protocol CarouselAccessibilitySupport {
     func accessibilityItem(index: Int) -> CarouselAccessibilityItem?


### PR DESCRIPTION
While working with the carousel we haven't support for additionals view in the `CarouselAccessibilityItem`. This PR is proposing additional field for child elements in carousel page so the accessibility can navigate thru them and then jumps bellow the carousel or swipe up or down to adjust carousel page.

The idea come from this session: https://developer.apple.com/videos/play/wwdc2018/230/