### PR TITLE
[FIX] Support isMarkupEnabled without explicit setting text

### DIFF
--- a/Sources/Cocoa/ThirdParty/MarkdownKit/MarkdownKit+UIKit.swift
+++ b/Sources/Cocoa/ThirdParty/MarkdownKit/MarkdownKit+UIKit.swift
@@ -68,7 +68,15 @@ extension UILabel {
     /// The default value is `false`.
     public var isMarkupEnabled: Bool {
         get { associatedObject(&AssociatedKey.isMarkupEnabled, default: MarkupText.appearance.isLabelEnabled) }
-        set { setAssociatedObject(&AssociatedKey.isMarkupEnabled, value: newValue) }
+        set {
+            let oldValue = isMarkupEnabled
+            setAssociatedObject(&AssociatedKey.isMarkupEnabled, value: newValue)
+            // If new value is `true` and have text, trigger parsing.
+            if newValue, hasText, oldValue != newValue {
+                let existingText = text
+                text = existingText
+            }
+        }
     }
 
     // TODO: Expose better api to get the parser text
@@ -101,7 +109,20 @@ extension UIButton {
     /// The default value is `false`.
     public var isMarkupEnabled: Bool {
         get { associatedObject(&AssociatedKey.isMarkupEnabled, default: false) }
-        set { setAssociatedObject(&AssociatedKey.isMarkupEnabled, value: newValue) }
+        set {
+            let oldValue = isMarkupEnabled
+
+            // Store values before assigment of `isMarkupEnabled`.
+            // Text and attribtuedText does not have the same value for UIButton.
+            let existingText = text
+            let existingHasText = hasText
+
+            setAssociatedObject(&AssociatedKey.isMarkupEnabled, value: newValue)
+            // If new value is `true` and have text, trigger parsing.
+            if newValue, existingHasText, oldValue != newValue {
+                text = existingText
+            }
+        }
     }
 
     private var markdownParser: MarkdownParser {


### PR DESCRIPTION
**Bug description**
UILabel and UIButton support property `isMarkupEnabled` which does not behave as expected.
The bug is that when we first set text to UILabel or UIButton, then set the value `isMarkupEnabled` the UI element does not respect the value of `isMarkupEnabled` - we need to set text in the UI element again to respect the value of `isMarkupEnabled`. 

**Proposed fix**
We will explicitly set the text again for UILabel and UIButton when the assigment of property `isMarkupEnabled`.

**Issues**
1. We don't see this behaviour in the Xcore codebase because we set explicitly that markup is enabled everywhere by default with this code: 
```
MarkupText.appearance.apply {
    $0.isLabelEnabled = true
    $0.isTextViewEnabled = true
}
```
which can be found in the file `Theme.swift`.

2. When we set value for text in UILabel, the `text` and `attributedText` values are the same. But this is an issue on UIButton. For the UIButton `text` and `attributedText` does not have the same value so we need to use a bit different approach while setting new text in setter of `isMarkupEnabled`. 

