### PR TITLE
[FIX] Dismiss webViewController as modal when needed

### DIFF
--- a/Sources/Cocoa/Components/WebView/WebViewController.swift
+++ b/Sources/Cocoa/Components/WebView/WebViewController.swift
@@ -425,7 +425,11 @@ extension WebViewController {
         let doneBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { [weak self] _ in
             guard let strongSelf = self else { return }
             strongSelf.didTapDoneButton?(strongSelf.webView.url)
-            strongSelf.navigationController?.popViewController(animated: true)
+            if strongSelf.isModal {
+                strongSelf.dismiss(animated: true, completion: nil)
+            } else {
+                strongSelf.navigationController?.popViewController(animated: true)
+            }
         }
 
         doneBarButtonItem.accessibilityIdentifier = "webViewController doneButton"


### PR DESCRIPTION
**Motivation**
When WebViewController is presented as modal the "Done" button is not working.