### PR TITLE
[FIX] Accessibility for LabelTextView

### DIFF
--- a/Sources/Cocoa/Components/LabelTextView.swift
+++ b/Sources/Cocoa/Components/LabelTextView.swift
@@ -41,6 +41,10 @@ open class LabelTextView: UITextView {
         #if canImport(Haring)
         isAccessibilityRotorHintEnabled = true
         #endif
+        isAccessibilityElement = true
+        // Disable line selection when view is
+        // tapped by user.
+        accessibilityTraits = .staticText
         dataDetectorTypes = .all
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
@@ -153,12 +157,5 @@ extension LabelTextView {
             return isTitle ? .header : super.accessibilityTraits
         }
         set { super.accessibilityTraits = newValue }
-    }
-
-    open override var isAccessibilityElement: Bool {
-        get {
-            font?.textStyle?.isTitle ?? false
-        }
-        set { super.isAccessibilityElement = newValue }
     }
 }


### PR DESCRIPTION
**Motivation**
I am proposing this because we need the ability to have accessible LabelTextView with even `.footnote` font-style.
This should not affect the fix proposed in https://github.com/zmian/xcore.swift/pull/70 as the only change is that we will let the client/caller set the accessibility and use it (we suppose that client/caller knows what he is doing)

@kameroli, please review and let me know what you think. 🙏 
